### PR TITLE
Setup Github Action for building release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '10.x'
       - name: Build project
         run: |
-          npm install && npm build
+          npm install && npm build && zip --junk-paths artifact ./build
 #       - name: Build project # This would actually build your project, using zip for an example artifact
 #         run: |
 #           zip --junk-paths my-artifact README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '10.x'
       - name: Build project
         run: |
-          npm install && npm run build && zip --junk-paths artifact ./build
+          npm install && npm run build && zip --junk-paths artifact ./build/*
 #       - name: Build project # This would actually build your project, using zip for an example artifact
 #         run: |
 #           zip --junk-paths my-artifact README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+on: push
+#   push:
+#     # Sequence of patterns matched against refs/tags
+#     tags:
+#     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+        
+      - name: Build project
+        run: | 
+          npm install && npm build &&                 
+#       - name: Build project # This would actually build your project, using zip for an example artifact
+#         run: |
+#           zip --junk-paths my-artifact README.md
+#       - name: Create Release
+#         id: create_release
+#         uses: actions/create-release@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           tag_name: ${{ github.ref }}
+#           release_name: Release ${{ github.ref }}
+#           draft: false
+#           prerelease: false
+#       - name: Upload Release Asset
+#         id: upload-release-asset 
+#         uses: actions/upload-release-asset@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+#           asset_path: ./my-artifact.zip
+#           asset_name: my-artifact.zip
+#           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-on: push
-#   push:
-#     # Sequence of patterns matched against refs/tags
-#     tags:
-#     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Upload Release Asset
 
@@ -20,26 +20,23 @@ jobs:
       - name: Build project
         run: |
           npm install && npm run build && zip --junk-paths artifact ./build/*
-#       - name: Build project # This would actually build your project, using zip for an example artifact
-#         run: |
-#           zip --junk-paths my-artifact README.md
-#       - name: Create Release
-#         id: create_release
-#         uses: actions/create-release@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         with:
-#           tag_name: ${{ github.ref }}
-#           release_name: Release ${{ github.ref }}
-#           draft: false
-#           prerelease: false
-#       - name: Upload Release Asset
-#         id: upload-release-asset 
-#         uses: actions/upload-release-asset@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         with:
-#           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-#           asset_path: ./artifact.zip
-#           asset_name: artifact.zip
-#           asset_content_type: application/zip
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./artifact.zip
+          asset_name: artifact.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '10.x'
       - name: Build project
         run: |
-          npm install && npm build && zip --junk-paths artifact ./build
+          npm install && npm run build && zip --junk-paths artifact ./build
 #       - name: Build project # This would actually build your project, using zip for an example artifact
 #         run: |
 #           zip --junk-paths my-artifact README.md
@@ -40,6 +40,6 @@ jobs:
 #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #         with:
 #           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-#           asset_path: ./my-artifact.zip
-#           asset_name: my-artifact.zip
+#           asset_path: ./artifact.zip
+#           asset_name: artifact.zip
 #           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-        
       - name: Build project
-        run: | 
-          npm install && npm build &&                 
+        run: |
+          npm install && npm build
 #       - name: Build project # This would actually build your project, using zip for an example artifact
 #         run: |
 #           zip --junk-paths my-artifact README.md

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 **Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [Past Election Map for Thailand](#past-election-map-for-thailand)
-  - [What is this about?](#what-is-this-about)
+    - [What is this about?](#what-is-this-about)
   - [Development](#development)
     - [Prerequisites](#prerequisites)
     - [Install dependencies](#install-dependencies)
     - [Run development mode](#run-development-mode)
     - [Build the project into a static web page](#build-the-project-into-a-static-web-page)
+    - [Release project](#release-project)
     - [Resources for Developers](#resources-for-developers)
     - [Environments](#environments)
   - [System Design](#system-design)
@@ -55,6 +56,14 @@ npm start
 ```
 npm run build
 ```
+
+### Release project
+
+```
+npm version [major|minor|patch] && git push --tags
+```
+
+When pushing tags, we have a GitHub Action that will automatically build the project and upload the build artifiact to [the release page](https://github.com/codeforthailand/past-election-map/releases).
 
 ### Resources for Developers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "past-election-map",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Past general election comparison map for Thailand",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "past-election-map",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Past general election comparison map for Thailand",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To test, please try after merging:
```
> nom version patch && git push --tags
```

You should expect a new release added to https://github.com/codeforthailand/past-election-map/releases with `artifact.zip` attached.

I hope the content of `artifact.zip` is correct. Could you please confirm it? 

Naturally, our admin might have a script for deploying a new release with a script parameterized in the following way.
```
https://github.com/codeforthailand/past-election-map/releases/download/v<VERSION>/artifact.zip
```